### PR TITLE
    Remove debug print statement from MajorityElement_169.java

### DIFF
--- a/src/main/array/MajorityElement_169.java
+++ b/src/main/array/MajorityElement_169.java
@@ -28,7 +28,6 @@ class MajorityElement_169 {
                 counter = 1;
             }
         }
-        System.out.println("new raw for test");
         return element;
     }
 }


### PR DESCRIPTION
    The unnecessary debug statement was removed to clean up the code. This statement was